### PR TITLE
Use bytes.Buffer rather than creating dozens of garbage strings

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,40 @@
+package dogstatsd
+
+import (
+	old "github.com/ooyala/go-dogstatsd"
+	"testing"
+)
+
+var myTags = []string{"a", "b", "c"}
+
+func BenchmarkNewSet(b *testing.B) {
+	c, _ := New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set("test", "item", myTags, 0.9999)
+	}
+}
+
+func BenchmarkOldSet(b *testing.B) {
+	c, _ := old.New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set("test", "item", myTags, 0.9999)
+	}
+}
+
+func BenchmarkNewGauge(b *testing.B) {
+	c, _ := New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Gauge("test", 1.23412, myTags, 0.9999)
+	}
+}
+
+func BenchmarkOldGauge(b *testing.B) {
+	c, _ := old.New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Gauge("test", 1.23412, myTags, 0.9999)
+	}
+}

--- a/dogstatsd.go
+++ b/dogstatsd.go
@@ -26,7 +26,19 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"strings"
+	"strconv"
+)
+
+var (
+	metricSeparator = []byte{':'}
+	rateSeparator   = []byte("|@")
+	tagSeparator    = []byte("|#")
+	gaugeSpec       = []byte("|g")
+	countSpec       = []byte("|c")
+	histogramSpec   = []byte("|h")
+	timerSpec       = []byte("|ms")
+	setSpec         = []byte("|s")
+	comma           = []byte{','}
 )
 
 // Client holds onto a connection and the other context necessary for every stasd packet.
@@ -55,26 +67,50 @@ func (c *Client) Close() error {
 }
 
 // send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.
-func (c *Client) send(name string, value string, tags []string, rate float64) error {
+func (c *Client) send(b *bytes.Buffer, spec []byte, tags []string, rate float64) error {
+	if _, err := b.Write(spec); err != nil {
+		return err
+	}
+
 	if rate < 1 {
 		if rand.Float64() < rate {
-			value = fmt.Sprintf("%s|@%f", value, rate)
+			if _, err := b.Write(rateSeparator); err != nil {
+				return err
+			}
+			/*
+				      The other option here would be:
+								bs := b.Bytes()
+								bs = strconv.AppendFloat(bs, rate, 'f', -1, 64)
+								b = bytes.NewBuffer(bs)
+				      Unfortunately, it does not perform better.
+			*/
+			if _, err := b.WriteString(strconv.FormatFloat(rate, 'f', -1, 64)); err != nil {
+				return err
+			}
 		} else {
 			return nil
 		}
 	}
 
-	if c.Namespace != "" {
-		name = fmt.Sprintf("%s%s", c.Namespace, name)
-	}
-
 	tags = append(c.Tags, tags...)
 	if len(tags) > 0 {
-		value = fmt.Sprintf("%s|#%s", value, strings.Join(tags, ","))
+		if _, err := b.Write(tagSeparator); err != nil {
+			return err
+		}
+		l := len(tags) - 1
+		for i, t := range tags {
+			if _, err := b.WriteString(t); err != nil {
+				return err
+			}
+			if i != l {
+				if _, err := b.Write(comma); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
-	data := fmt.Sprintf("%s:%s", name, value)
-	_, err := c.conn.Write([]byte(data))
+	_, err := c.conn.Write(b.Bytes())
 	return err
 }
 
@@ -94,32 +130,76 @@ func (c *Client) Event(title string, text string, tags []string) error {
 	return err
 }
 
+func (c *Client) start(b *bytes.Buffer, name string) error {
+	var err error
+	if _, err = b.WriteString(c.Namespace); err != nil {
+		return err
+	}
+	if _, err = b.WriteString(name); err != nil {
+		return err
+	}
+	if _, err = b.Write(metricSeparator); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Gauge measures the value of a metric at a particular time
 func (c *Client) Gauge(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|g", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
+		return err
+	}
+	return c.send(&b, gaugeSpec, tags, rate)
 }
 
 // Count tracks how many times something happened per second
 func (c *Client) Count(name string, value int64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%d|c", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatInt(value, 10)); err != nil {
+		return err
+	}
+	return c.send(&b, countSpec, tags, rate)
 }
 
 // Histogram tracks the statistical distribution of a set of values
 func (c *Client) Histogram(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|h", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
+		return err
+	}
+	return c.send(&b, histogramSpec, tags, rate)
 }
 
 // Timer tracks the statistical distribution of a set of durations
 func (c *Client) Timer(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|ms", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
+		return err
+	}
+	return c.send(&b, timerSpec, tags, rate)
 }
 
 // Set counts the number of unique elements in a group
 func (c *Client) Set(name string, value string, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%s|s", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(value); err != nil {
+		return err
+	}
+	return c.send(&b, setSpec, tags, rate)
 }

--- a/dogstatsd_test.go
+++ b/dogstatsd_test.go
@@ -18,14 +18,14 @@ var dogstatsdTests = []struct {
 	Rate            float64
 	Expected        string
 }{
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1.000000|g"},
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1.000000|g|@0.999999"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1.000000|g|#tagA"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1.000000|g|#tagA,tagB"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1.000000|g|@0.999999|#tagA"},
+	{"", nil, "Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1|g"},
+	{"", nil, "Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1|g|@0.999999"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1|g|#tagA"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1|g|#tagA,tagB"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1|g|@0.999999|#tagA"},
 	{"", nil, "Count", "test.count", int64(1), []string{"tagA"}, 1.0, "test.count:1|c|#tagA"},
 	{"", nil, "Count", "test.count", int64(-1), []string{"tagA"}, 1.0, "test.count:-1|c|#tagA"},
-	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.300000|h|#tagA"},
+	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.3|h|#tagA"},
 	{"", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA"},
 	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA"},
 	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA"},


### PR DESCRIPTION
@Shopify/stack @mkobetic @snormore

I was playing with this on the flight to Chicago, and managed to reduce allocations and walltime quite a bit.

I can't think of any way to further reduce allocations short of implementing a `WriteFloat` counterpart to `strconv.AppendFloat`.

```
% go test -test.bench . -test.benchmem
PASS
BenchmarkNewSet   500000              3394 ns/op             201 B/op          4 allocs/op
BenchmarkOldSet   500000              5205 ns/op             297 B/op         14 allocs/op
BenchmarkNewGauge         500000              3734 ns/op             241 B/op          6 allocs/op
BenchmarkOldGauge         500000              5561 ns/op             307 B/op         13 allocs/op
```
